### PR TITLE
Repo hwrp work

### DIFF
--- a/lib/artifactory/resources/repository.rb
+++ b/lib/artifactory/resources/repository.rb
@@ -195,6 +195,20 @@ module Artifactory
       response['children']
     end
 
+    #
+    # Delete this repository from artifactory, suppressing any +ResourceNotFound+
+    # exceptions might occur.
+    #
+    # @return [Boolean]
+    #   true if the object was deleted successfully, false otherwise
+    #
+    def delete
+      client.delete(api_path)
+      true
+    rescue Error::HTTPError => e
+      false
+    end
+
     private
 
     #


### PR DESCRIPTION
@sethvargo @schisamo 

A couple of changes needed for the artifactory repository HWRP.  
- Artifactory returns 400 on attempts to access nonexistent repos, not 404.
- Added attribute for repository layout.
- Allow repositories to be deleted.
