### PR TITLE
Expose `Net::HTTP#read_timeout` configuration

### DIFF
--- a/lib/artifactory/client.rb
+++ b/lib/artifactory/client.rb
@@ -195,6 +195,11 @@ module Artifactory
       connection = Net::HTTP.new(uri.host, uri.port,
         proxy_address, proxy_port, proxy_username, proxy_password)
 
+      # The artifacts being uploaded might be large, so there’s a good chance
+      # we'll need to bump this higher than the `Net::HTTP` default of 60
+      # seconds.
+      connection.read_timeout = read_timeout
+
       # Apply SSL, if applicable
       if uri.scheme == 'https'
         require 'net/https' unless defined?(Net::HTTPS)

--- a/lib/artifactory/configurable.rb
+++ b/lib/artifactory/configurable.rb
@@ -22,6 +22,7 @@ module Artifactory
           :ssl_pem_file,
           :ssl_verify,
           :user_agent,
+          :read_timeout,
         ]
       end
     end

--- a/lib/artifactory/defaults.rb
+++ b/lib/artifactory/defaults.rb
@@ -111,6 +111,15 @@ module Artifactory
           %w[t y].include?(ENV['ARTIFACTORY_SSL_VERIFY'].downcase[0])
         end
       end
+
+      #
+      # Number of seconds to wait for a response from Artifactory
+      #
+      # @return [Integer, nil]
+      #
+      def read_timeout
+        ENV['ARTIFACTORY_READ_TIMEOUT'] || 120
+      end
     end
   end
 end


### PR DESCRIPTION
The artifacts being uploaded might be large, so there’s a good chance 
we'll need to bump this higher than the `Net::HTTP` default of 60 
seconds.

/cc @opscode/release-engineers 
