### PR TITLE
Matrix properties should be CGI escaped

### DIFF
--- a/lib/artifactory/resources/base.rb
+++ b/lib/artifactory/resources/base.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+require 'cgi'
 require 'json'
 
 module Artifactory
@@ -321,8 +322,8 @@ module Artifactory
     #
     def to_matrix_properties(hash = {})
       properties = hash.map do |k, v|
-        key   = URI.escape(k.to_s)
-        value = URI.escape(v.to_s)
+        key   = CGI.escape(k.to_s)
+        value = CGI.escape(v.to_s)
 
         "#{key}=#{value}"
       end

--- a/spec/unit/resources/artifact_spec.rb
+++ b/spec/unit/resources/artifact_spec.rb
@@ -54,11 +54,27 @@ module Artifactory
 
       context 'when matrix properties are given' do
         it 'converts the hash into matrix properties' do
-          expect(client).to receive(:put).with('libs-release-local;branch=master;user=Seth%20Vargo/remote/path', file, {})
+          expect(client).to receive(:put).with('libs-release-local;branch=master;user=Seth/remote/path', file, {})
 
           subject.upload('libs-release-local', '/remote/path',
             branch: 'master',
+            user: 'Seth',
+          )
+        end
+
+        it 'converts spaces to "+" characters' do
+          expect(client).to receive(:put).with('libs-release-local;user=Seth+Vargo/remote/path', file, {})
+
+          subject.upload('libs-release-local', '/remote/path',
             user: 'Seth Vargo',
+          )
+        end
+
+        it 'converts "+" to "%2B"' do
+          expect(client).to receive(:put).with('libs-release-local;version=12.0.0-alpha.1%2B20140826080510.git.50.f5ff271/remote/path', file, {})
+
+          subject.upload('libs-release-local', '/remote/path',
+            version: '12.0.0-alpha.1+20140826080510.git.50.f5ff271',
           )
         end
       end


### PR DESCRIPTION
`URI.escape` has been deprecated: http://stackoverflow.com/a/2832003

Furthermore URI.escape and does not properly encode things like plus signs (`+`) which should be turned into a `%2B` while actual spaces should be turned into a `+`!

I noticed this bug when examining a matrix property for a build version. The original build version was: 
`12.0.0-alpha.1+20140826080510.git.50.f5ff271` 
but Artifactory had stored it as: 
`12.0.0-alpha.1 20140826080510.git.50.f5ff271`!

/cc @opscode/release-engineers 
