### PR TITLE
Update typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ This will given you "Rails-like" access to the top-level Artifactory resources l
 
 ```ruby
 System.info
-Respository.all
+Repository.all
 ```
 
 If you choose not to include the module (for namespacing reasons), you will need to specify the full module path to access resources:
 
 ```ruby
 Artifactory::Resource::System.info
-Artifactory::Resource::Respository.all
+Artifactory::Resource::Repository.all
 ```
 
 ### Create a connection

--- a/lib/artifactory/resources/repository.rb
+++ b/lib/artifactory/resources/repository.rb
@@ -39,7 +39,7 @@ module Artifactory
       #
       # Find (fetch) a repository by name.
       #
-      # @example Find a respository by named key
+      # @example Find a repository by named key
       #   Repository.find(name: 'libs-release-local') #=> #<Resource::Artifact>
       #
       # @param [Hash] options


### PR DESCRIPTION
This is a minor typo in the docs that disallows copy/paste attempts to try the gem
