### PR TITLE
Adding support for "usage" and "creation" search endpoints

### DIFF
--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -227,6 +227,47 @@ module Artifactory
       end
 
       #
+      # Search for an artifact by its creation date
+      #
+      # @example Search for all repositories with the given creation date range
+      #   Artifact.usage_search(
+      #     from : 1414800000000,
+      #     to   : 1414871200000,
+      #   )
+      #
+      # @example Search for all artifacts with the given creation date range in a repo
+      #   Artifact.usage_search(
+      #     from : 1414800000000,
+      #     to   : 1414871200000,
+      #     repos: 'libs-release-local',
+      #   )
+      #
+      # @param [Hash] options
+      #   the list of options to search with
+      #
+      # @option options [Artifactory::Client] :client
+      #   the client object to make the request with
+      # @option options [Long] :from
+      #   the creation start date of the artifact to search for (millis since epoch)
+      # @option options [Long] :to
+      #   the creation end date of the artifact to search for (millis since epoch)
+      # @option options [String, Array<String>] :repos
+      #   the list of repos to search
+      #
+      # @return [Array<Resource::Artifact>]
+      #   a list of artifacts that match the query
+      #
+      def creation_search(options = {})
+        client = extract_client!(options)
+        params = Util.slice(options, :from, :to, :repos)
+        format_repos!(params)
+
+        client.get('/api/search/creation', params)['results'].map do |artifact|
+          from_url(artifact['uri'], client: client)
+        end
+      end
+
+      #
       # Get all versions of an artifact.
       #
       # @example Get all versions of a given artifact

--- a/spec/integration/resources/artifact_spec.rb
+++ b/spec/integration/resources/artifact_spec.rb
@@ -56,6 +56,10 @@ module Artifactory
       it_behaves_like 'an artifact search endpoint', :usage_search, notUsedSince: '1414800000'
     end
 
+    describe '.creation_search' do
+      it_behaves_like 'an artifact search endpoint', :creation_search, from: '1414800000'
+    end
+
     describe '.versions' do
       it 'returns an array of versions' do
         response = described_class.versions

--- a/spec/support/api_server/artifact_endpoints.rb
+++ b/spec/support/api_server/artifact_endpoints.rb
@@ -39,6 +39,13 @@ module Artifactory
         end
       end
 
+      app.get('/api/search/creation') do
+        content_type 'application/vnd.org.jfrog.artifactory.search.ArtifactCreationResult+json'
+        artifacts_for_conditions do
+          params['from'] == '1414800000'
+        end
+      end
+
       app.get('/api/search/versions') do
         content_type 'application/vnd.org.jfrog.artifactory.search.ArtifactVersionsResult+json'
         JSON.fast_generate(

--- a/spec/unit/resources/artifact_spec.rb
+++ b/spec/unit/resources/artifact_spec.rb
@@ -232,6 +232,31 @@ module Artifactory
       end
     end
 
+    describe '.creation_search' do
+      let(:response) { { 'results' => [] } }
+
+      it 'calls /api/search/creation' do
+        expect(client).to receive(:get).with('/api/search/creation', {}).once
+        described_class.creation_search
+      end
+
+      it 'slices the correct parameters' do
+        expect(client).to receive(:get).with('/api/search/creation',
+          from:  1414800000000,
+          to: 1414871200000,
+        ).once
+        described_class.creation_search(
+          from:  1414800000000,
+          to: 1414871200000,
+          fizz: 'foo',
+        )
+      end
+
+      it 'returns an array of objects' do
+        expect(described_class.creation_search).to be_a(Array)
+      end
+    end
+
     describe '.versions' do
       let(:response) { { 'results' => [] } }
 


### PR DESCRIPTION
The following documented endpoints are missing from the gem.

http://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-ArtifactsNotDownloadedSince
http://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-ArtifactsCreatedinDateRange

This doesn't get the gem fully up to spec with the documentation. I'll admit that I'm only adding what I intend to use... To that end, I _have_ installed this locally to further verify functionality.

Good gem. Thanks for creating it! :beers: 
