### PR TITLE
Fix provide data to post call in Artifact.rb

### DIFF
--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -678,7 +678,7 @@ module Artifactory
 
       endpoint = File.join('/api', action.to_s, relative_path) + '?' + params.join('&')
 
-      client.post(endpoint)
+      client.post(endpoint, {})
     end
   end
 end


### PR DESCRIPTION
Artifactory reads the query string rather than posted form data, but the client.post method still requires that data as an argument. Provide an empty hash.
