### PR TITLE
Provide data to post call in Artifact.rb

### DIFF
--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -678,7 +678,7 @@ module Artifactory
 
       endpoint = File.join('/api', action.to_s, relative_path) + '?' + params.join('&')
 
-      client.post(endpoint)
+      client.post(endpoint, {})
     end
   end
 end

--- a/spec/unit/resources/artifact_spec.rb
+++ b/spec/unit/resources/artifact_spec.rb
@@ -498,12 +498,12 @@ module Artifactory
       end
 
       it 'sends POST to the client with parsed params' do
-        expect(client).to receive(:post).with('/api/move/foo/bar/artifact.deb?to=/to/path')
+        expect(client).to receive(:post).with('/api/move/foo/bar/artifact.deb?to=/to/path', {})
         subject.copy_or_move(:move, '/to/path')
       end
 
       it 'adds the correct parameters to the request' do
-        expect(client).to receive(:post).with('/api/move/foo/bar/artifact.deb?to=/to/path&failFast=1&dry=1')
+        expect(client).to receive(:post).with('/api/move/foo/bar/artifact.deb?to=/to/path&failFast=1&dry=1', {})
         subject.copy_or_move(:move, '/to/path', fail_fast: true, dry_run: true)
       end
     end


### PR DESCRIPTION
Artifactory::Client's post method expects some form data as a required argument. Artifactory will ignore it and use the query string instead (this is rather unusual, as the comments call out) but the API client still wants _something_, so provide it.
