### PR TITLE
Ensure embedded requests respect configured settings

### DIFF
--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -438,7 +438,7 @@ module Artifactory
     #   the list of properties
     #
     def properties
-      @properties ||= client.get(uri, properties: nil)['properties']
+      @properties ||= client.get(File.join('/api/storage', relative_path), properties: nil)['properties']
     end
 
     #

--- a/lib/artifactory/resources/base.rb
+++ b/lib/artifactory/resources/base.rb
@@ -16,6 +16,7 @@
 
 require 'cgi'
 require 'json'
+require 'uri'
 
 module Artifactory
   class Resource::Base
@@ -104,8 +105,11 @@ module Artifactory
       # @return [~Resource::Base]
       #
       def from_url(url, options = {})
+        # Parse the URL and only use the path so the configured
+        # endpoint/proxy/SSL settings are used in the GET request.
+        path = URI.parse(url).path
         client = extract_client!(options)
-        from_hash(client.get(url), client: client)
+        from_hash(client.get(path), client: client)
       end
 
       #

--- a/spec/unit/resources/artifact_spec.rb
+++ b/spec/unit/resources/artifact_spec.rb
@@ -452,15 +452,16 @@ module Artifactory
         { 'properties' => properties }
       end
       let(:client) { double(get: response) }
-      let(:uri) { '/artifact.deb' }
+      let(:relative_path) { '/api/storage/some-repo/path/artifact.deb' }
+      let(:artifact_uri) { File.join('http://33.33.33.11', relative_path) }
 
       before do
-        subject.client   = client
-        subject.uri = uri
+        subject.client = client
+        subject.uri    = artifact_uri
       end
 
       it 'gets the properties from the server' do
-        expect(client).to receive(:get).with(uri, properties: nil).once
+        expect(client).to receive(:get).with(relative_path, properties: nil).once
         expect(subject.properties).to eq(properties)
       end
 

--- a/spec/unit/resources/base_spec.rb
+++ b/spec/unit/resources/base_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 module Artifactory
   describe Resource::Base do
+    let(:client) { double }
+
+    before do
+      allow(Artifactory).to receive(:client).and_return(client)
+    end
+
     describe '.attribute' do
       before { described_class.attribute(:bacon) }
 
@@ -74,19 +80,30 @@ module Artifactory
           expect(options).to eq(options)
         end
       end
+    end
 
-      describe '.url_safe' do
-        let(:string) { double(to_s: 'string') }
+    describe '.from_url' do
+      let(:relative_path) { '/api/storage/omnibus-unstable-local/com/getchef/harmony/0.1.0+20151111083608.git.15.8736e1e/el/5/harmony-0.1.0+20151111083608.git.15.8736e1e-1.el5.x86_64.rpm' }
 
-        it 'delegates to URI.escape' do
-          expect(URI).to receive(:escape).once
-          described_class.url_safe(string)
-        end
+      it 'only uses the path from absolute URLs' do
 
-        it 'converts the value to a string' do
-          expect(string).to receive(:to_s).once
-          described_class.url_safe(string)
-        end
+        expect(described_class).to receive(:from_hash)
+        expect(client).to receive(:get).with(relative_path)
+        described_class.from_url(File.join('http://33.33.33.11', relative_path))
+      end
+    end
+
+    describe '.url_safe' do
+      let(:string) { double(to_s: 'string') }
+
+      it 'delegates to URI.escape' do
+        expect(URI).to receive(:escape).once
+        described_class.url_safe(string)
+      end
+
+      it 'converts the value to a string' do
+        expect(string).to receive(:to_s).once
+        described_class.url_safe(string)
       end
     end
 

--- a/spec/unit/resources/permission_target_spec.rb
+++ b/spec/unit/resources/permission_target_spec.rb
@@ -47,7 +47,7 @@ module Artifactory
 
       it 'constructs a new instance from the result' do
         expect(described_class).to receive(:from_hash).once
-        described_class.from_url('/api/security/permissions/Any Remote')
+        described_class.from_url('/api/security/permissions/AnyRemote')
       end
     end
 


### PR DESCRIPTION
Artifactory returns fully-qualified object URLs that do not respect the configured endpoint/proxy/SSL client settings. This change ensures the embedded GET request is made with a relative path which does use these client settings.

/cc @chef/engineering-services @sethvargo 