### PR TITLE
Fix embedded requests when endpoint has a non-empty path

### DIFF
--- a/lib/artifactory/resources/base.rb
+++ b/lib/artifactory/resources/base.rb
@@ -109,6 +109,11 @@ module Artifactory
         # endpoint/proxy/SSL settings are used in the GET request.
         path = URI.parse(url).path
         client = extract_client!(options)
+        # If the endpoint contains a path part, we must remove the
+        # endpoint path part from path, because the client uses
+        # endpoint + path as its full URI.
+        endpoint_path = URI.parse(client.endpoint).path
+        path.slice!(endpoint_path)
         from_hash(client.get(path), client: client)
       end
 

--- a/spec/unit/resources/artifact_spec.rb
+++ b/spec/unit/resources/artifact_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 module Artifactory
   describe Resource::Artifact do
     let(:client) { double(:client) }
+    let(:endpoint_host) { 'http://33.33.33.11' }
+    let(:endpoint) { "#{endpoint_host}/" }
 
     before(:each) do
       allow(Artifactory).to receive(:client).and_return(client)
@@ -369,6 +371,7 @@ module Artifactory
       let(:response) { {} }
 
       it 'constructs a new instance from the result' do
+        expect(client).to receive(:endpoint).and_return(endpoint)
         expect(described_class).to receive(:from_hash).once
         described_class.from_url('/some/artifact/path.deb')
       end

--- a/spec/unit/resources/group_spec.rb
+++ b/spec/unit/resources/group_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 module Artifactory
   describe Resource::Group do
     let(:client) { double(:client) }
+    let(:endpoint_host) { 'http://33.33.33.11' }
+    let(:endpoint) { "#{endpoint_host}/" }
 
     before(:each) do
       allow(Artifactory).to receive(:client).and_return(client)
@@ -46,6 +48,7 @@ module Artifactory
       let(:response) { {} }
 
       it 'constructs a new instance from the result' do
+        expect(client).to receive(:endpoint).and_return(endpoint)
         expect(described_class).to receive(:from_hash).once
         described_class.from_url('/api/security/groups/readers')
       end

--- a/spec/unit/resources/permission_target_spec.rb
+++ b/spec/unit/resources/permission_target_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 module Artifactory
   describe Resource::PermissionTarget do
     let(:client) { double(:client) }
+    let(:endpoint_host) { 'http://33.33.33.11' }
+    let(:endpoint) { "#{endpoint_host}/" }
 
     before(:each) do
       allow(Artifactory).to receive(:client).and_return(client)
@@ -46,6 +48,7 @@ module Artifactory
       let(:response) { {} }
 
       it 'constructs a new instance from the result' do
+        expect(client).to receive(:endpoint).and_return(endpoint)
         expect(described_class).to receive(:from_hash).once
         described_class.from_url('/api/security/permissions/AnyRemote')
       end

--- a/spec/unit/resources/user_spec.rb
+++ b/spec/unit/resources/user_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 module Artifactory
   describe Resource::User do
     let(:client) { double(:client) }
+    let(:endpoint_host) { 'http://33.33.33.11' }
+    let(:endpoint) { "#{endpoint_host}/" }
 
     before(:each) do
       allow(Artifactory).to receive(:client).and_return(client)
@@ -46,6 +48,7 @@ module Artifactory
       let(:response) { {} }
 
       it 'constructs a new instance from the result' do
+        expect(client).to receive(:endpoint).and_return(endpoint)
         expect(described_class).to receive(:from_hash).once
         described_class.from_url('/api/security/users/readers')
       end


### PR DESCRIPTION
Version 2.3.1 introduced a problem with Artifactory endpoints where the endpoint
URL has a path part that is not empty, e.g., http://artifacts.example.com/artifactory.
In Resource::Base.from_url, we need to get the path relative to the endpoint, not
the entire path from the URL.

This fixes issue #60.