### PR TITLE
Ensure url is encoded since artifactory doesn't do that for us #65

### DIFF
--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -103,7 +103,7 @@ module Artifactory
         format_repos!(params)
 
         client.get('/api/search/gavc', params)['results'].map do |artifact|
-          from_url(artifact['uri'], client: client)
+          from_url(url_safe(artifact['uri']), client: client)
         end
       end
 
@@ -142,7 +142,7 @@ module Artifactory
         format_repos!(params)
 
         client.get('/api/search/prop', params)['results'].map do |artifact|
-          from_url(artifact['uri'], client: client)
+          from_url(url_safe(artifact['uri']), client: client)
         end
       end
 
@@ -181,7 +181,7 @@ module Artifactory
         format_repos!(params)
 
         client.get('/api/search/checksum', params)['results'].map do |artifact|
-          from_url(artifact['uri'], client: client)
+          from_url(url_safe(artifact['uri']), client: client)
         end
       end
 
@@ -222,7 +222,7 @@ module Artifactory
         format_repos!(params)
 
         client.get('/api/search/usage', params)['results'].map do |artifact|
-          from_url(artifact['uri'], client: client)
+          from_url(url_safe(artifact['uri']), client: client)
         end
       end
 
@@ -263,7 +263,7 @@ module Artifactory
         format_repos!(params)
 
         client.get('/api/search/creation', params)['results'].map do |artifact|
-          from_url(artifact['uri'], client: client)
+          from_url(url_safe(artifact['uri']), client: client)
         end
       end
 

--- a/lib/artifactory/resources/base.rb
+++ b/lib/artifactory/resources/base.rb
@@ -107,12 +107,12 @@ module Artifactory
       def from_url(url, options = {})
         # Parse the URL and only use the path so the configured
         # endpoint/proxy/SSL settings are used in the GET request.
-        path = URI.parse(url_safe(url)).path
+        path = URI.parse(url).path
         client = extract_client!(options)
         # If the endpoint contains a path part, we must remove the
         # endpoint path part from path, because the client uses
         # endpoint + path as its full URI.
-        endpoint_path = URI.parse(url_safe(client.endpoint)).path
+        endpoint_path = URI.parse(client.endpoint).path
         path.slice!(endpoint_path)
         from_hash(client.get(path), client: client)
       end

--- a/lib/artifactory/resources/base.rb
+++ b/lib/artifactory/resources/base.rb
@@ -107,12 +107,12 @@ module Artifactory
       def from_url(url, options = {})
         # Parse the URL and only use the path so the configured
         # endpoint/proxy/SSL settings are used in the GET request.
-        path = URI.parse(url).path
+        path = URI.parse(url_safe(url)).path
         client = extract_client!(options)
         # If the endpoint contains a path part, we must remove the
         # endpoint path part from path, because the client uses
         # endpoint + path as its full URI.
-        endpoint_path = URI.parse(client.endpoint).path
+        endpoint_path = URI.parse(url_safe(client.endpoint)).path
         path.slice!(endpoint_path)
         from_hash(client.get(path), client: client)
       end


### PR DESCRIPTION
The response for artifacts does not encode the returned url.    For cases with a whitespace or non-URL friendly characters in the URL this results in an error when using search.   
