### PR TITLE
read_timeout needs to be an integer.

### DIFF
--- a/lib/artifactory/defaults.rb
+++ b/lib/artifactory/defaults.rb
@@ -134,7 +134,7 @@ module Artifactory
       # @return [Integer, nil]
       #
       def read_timeout
-        ENV['ARTIFACTORY_READ_TIMEOUT'] || 120
+        ENV['ARTIFACTORY_READ_TIMEOUT'].to_i || 120
       end
     end
   end

--- a/lib/artifactory/version.rb
+++ b/lib/artifactory/version.rb
@@ -15,5 +15,5 @@
 #
 
 module Artifactory
-  VERSION = '2.3.3'
+  VERSION = '2.3.4'
 end


### PR DESCRIPTION
Setting read timeout via an env variable resulted in a String->Integer error because ENV vars are always strings and http::request expects an int