### PR TITLE
Coerce `ARTIFACTORY_READ_TIMEOUT` value to integer

### DIFF
--- a/lib/artifactory/defaults.rb
+++ b/lib/artifactory/defaults.rb
@@ -134,7 +134,7 @@ module Artifactory
       # @return [Integer, nil]
       #
       def read_timeout
-        ENV['ARTIFACTORY_READ_TIMEOUT'] || 120
+        ENV['ARTIFACTORY_READ_TIMEOUT'].to_i || 120
       end
     end
   end

--- a/spec/unit/resources/defaults_spec.rb
+++ b/spec/unit/resources/defaults_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+module Artifactory
+  describe Defaults do
+    describe "read_timeout" do
+      it "returns Fixnums even when given strings" do
+        begin
+          original_timeout = ENV['ARTIFACTORY_READ_TIMEOUT']
+          ENV['ARTIFACTORY_READ_TIMEOUT'] = "60"
+
+          expect(subject.read_timeout).to be_an_instance_of Fixnum
+        ensure
+          if original_timeout.nil?
+            ENV.delete 'ARTIFACTORY_READ_TIMEOUT'
+          else
+            ENV['ARTIFACTORY_READ_TIMEOUT'] = original_timeout
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/resources/defaults_spec.rb
+++ b/spec/unit/resources/defaults_spec.rb
@@ -3,19 +3,16 @@ require "spec_helper"
 module Artifactory
   describe Defaults do
     describe "read_timeout" do
-      it "returns Fixnums even when given strings" do
-        begin
-          original_timeout = ENV['ARTIFACTORY_READ_TIMEOUT']
-          ENV['ARTIFACTORY_READ_TIMEOUT'] = "60"
+      before(:each) do
+        ENV['ARTIFACTORY_READ_TIMEOUT'] = "60"
+      end
 
-          expect(subject.read_timeout).to be_an_instance_of Fixnum
-        ensure
-          if original_timeout.nil?
-            ENV.delete 'ARTIFACTORY_READ_TIMEOUT'
-          else
-            ENV['ARTIFACTORY_READ_TIMEOUT'] = original_timeout
-          end
-        end
+      after(:each) do
+        ENV.delete('ARTIFACTORY_READ_TIMEOUT')
+      end
+
+      it "returns Fixnums even when given strings" do
+        expect(subject.read_timeout).to be_an_instance_of Fixnum
       end
     end
   end


### PR DESCRIPTION
Added `to_i` to `ENV['ARTIFACTORY_READ_TIMEOUT']` to ensure it's read as an integer.  This prevents weirdo environment variable problems from causing opaque errors down in the guts of `protocol.rb` if this value is a String (as `protocol.rb` can't coerce a String to an Interval)