### PR TITLE
Add url attribute to support remote repositories

### DIFF
--- a/lib/artifactory/resources/repository.rb
+++ b/lib/artifactory/resources/repository.rb
@@ -81,6 +81,7 @@ module Artifactory
     attribute :rclass, 'local'
     attribute :snapshot_version_behavior, 'non-unique'
     attribute :suppress_pom_consistency_checks, false
+    attribute :url, ''
 
     #
     # Creates or updates a repository configuration depending on if the

--- a/spec/unit/resources/repository_spec.rb
+++ b/spec/unit/resources/repository_spec.rb
@@ -64,6 +64,7 @@ module Artifactory
           'calculateYumMetadata'         => false,
           'yumRootDepth'                 => 0,
           'rclass'                       => 'local',
+          'url'                          => 'someurl',
         }
       end
 
@@ -85,6 +86,7 @@ module Artifactory
         expect(instance.repo_layout_ref).to eq('simple-default')
         expect(instance.snapshot_version_behavior).to eq('unique')
         expect(instance.suppress_pom_consistency_checks).to be_truthy
+        expect(instance.url).to eq('someurl')
       end
     end
 


### PR DESCRIPTION
Added a url attribute to the repository resource, because it
allows reading and writing remote repositories.

Previously, to read the URL of a remote repository, we had to
make a raw GET request as in: /api/repositories/jcenter,
which would return the URL.

And previously, to create a remote repository, we had to make a
raw PUT request as in:
Artifactory.put('/api/repositories/myremote', json, headers)

With this new attribute, we can work with the Repository resource
directly.