### PR TITLE
Ensure read_timeout returns a non-zero value.

### DIFF
--- a/lib/artifactory/defaults.rb
+++ b/lib/artifactory/defaults.rb
@@ -131,10 +131,14 @@ module Artifactory
       #
       # Number of seconds to wait for a response from Artifactory
       #
-      # @return [Integer, nil]
+      # @return [Integer]
       #
       def read_timeout
-        ENV['ARTIFACTORY_READ_TIMEOUT'].to_i || 120
+        if ENV['ARTIFACTORY_READ_TIMEOUT']
+          ENV['ARTIFACTORY_READ_TIMEOUT'].to_i
+        else
+          120
+        end
       end
     end
   end

--- a/spec/unit/resources/defaults_spec.rb
+++ b/spec/unit/resources/defaults_spec.rb
@@ -14,6 +14,14 @@ module Artifactory
       it "returns Fixnums even when given strings" do
         expect(subject.read_timeout).to be_an_instance_of Fixnum
       end
+
+      it 'returns a non-zero value' do
+        expect(subject.read_timeout).to be > 0
+      end
+
+      it 'does not return a nil value' do
+        expect(subject.read_timeout).not_to be nil
+      end
     end
   end
 end


### PR DESCRIPTION
We inadvertently introduced a regression when converting the `ARTIFACTORY_READ_TIMEOUT` value to a `Fixnum`. In the case where the environment variable was not set, it would return `nil` which is
mutated to a `0` value when `nil.to_i` is run. This would cause all connections to fail which did not have the value set as Net:HTTP would not wait for a response before raising `Net::ReadTimeout`.

@chef/engineering-services 