### PR TITLE
Add support for extended YUM repo attributes

### DIFF
--- a/lib/artifactory/resources/repository.rb
+++ b/lib/artifactory/resources/repository.rb
@@ -82,6 +82,8 @@ module Artifactory
     attribute :snapshot_version_behavior, 'non-unique'
     attribute :suppress_pom_consistency_checks, false
     attribute :url, ''
+    attribute :yum_root_depth, 0
+    attribute :calculate_yum_metadata, false
 
     #
     # Creates or updates a repository configuration depending on if the

--- a/spec/unit/resources/repository_spec.rb
+++ b/spec/unit/resources/repository_spec.rb
@@ -62,7 +62,7 @@ module Artifactory
           'propertySets'                 => ['artifactory'],
           'archiveBrowsingEnabled'       => false,
           'calculateYumMetadata'         => false,
-          'yumRootDepth'                 => 0,
+          'yumRootDepth'                 => 3,
           'rclass'                       => 'local',
           'url'                          => 'someurl',
         }
@@ -87,6 +87,8 @@ module Artifactory
         expect(instance.snapshot_version_behavior).to eq('unique')
         expect(instance.suppress_pom_consistency_checks).to be_truthy
         expect(instance.url).to eq('someurl')
+        expect(instance.yum_root_depth).to eq(3)
+        expect(instance.calculate_yum_metadata).to eq(false)
       end
     end
 


### PR DESCRIPTION
These extra attributes allow us to tweak some default behavior in Artifactory-managed YUM repos.

Signed-off-by: Seth Chisamore <schisamo@chef.io>

/cc @chef/engineering-services 