### PR TITLE
Ensure URI from artifacts are escaped

### DIFF
--- a/lib/artifactory/resources/base.rb
+++ b/lib/artifactory/resources/base.rb
@@ -107,7 +107,7 @@ module Artifactory
       def from_url(url, options = {})
         # Parse the URL and only use the path so the configured
         # endpoint/proxy/SSL settings are used in the GET request.
-        path = URI.parse(url).path
+        path = URI.parse(url_safe(url)).path
         client = extract_client!(options)
         # If the endpoint contains a path part, we must remove the
         # endpoint path part from path, because the client uses
@@ -241,7 +241,7 @@ module Artifactory
       #   the URL-safe version of the string
       #
       def url_safe(value)
-        URI.escape(value.to_s)
+        URI.escape(URI.unescape(value.to_s))
       end
     end
 

--- a/spec/integration/resources/artifact_spec.rb
+++ b/spec/integration/resources/artifact_spec.rb
@@ -6,7 +6,7 @@ module Artifactory
       it "finds artifacts by #{name}" do
         response = described_class.send(name, options)
         expect(response).to be_a(Array)
-        expect(response.size).to eq(2)
+        expect(response.size).to eq(3)
 
         artifact_1 = response[0]
         expect(artifact_1).to be_a(described_class)
@@ -15,6 +15,10 @@ module Artifactory
         artifact_2 = response[1]
         expect(artifact_2).to be_a(described_class)
         expect(artifact_2.repo).to eq('ext-release-local')
+
+        artifact_3 = response[2]
+        expect(artifact_3).to be_a(described_class)
+        expect(artifact_3.repo).to eq('bin-release-local')
       end
 
       it "finds artifacts by repo" do

--- a/spec/support/api_server/artifact_endpoints.rb
+++ b/spec/support/api_server/artifact_endpoints.rb
@@ -111,6 +111,31 @@ module Artifactory
         )
       end
 
+      app.get('/api/storage/bin-release-local/org/acme/artifact 1.0.0.msi') do
+        content_type 'application/vnd.org.jfrog.artifactory.storage.FileInfo+json'
+        JSON.fast_generate(
+          'uri'          => server_url.join('/api/storage/bin-release-local/org/acme/artifact 1.0.0.msi'),
+          'downloadUri'  => server_url.join('/artifactory/bin-release-local/org/acme/artifact 1.0.0.msi'),
+          'repo'         => 'bin-release-local',
+          'path'         => '/org/acme/artifact 1.0.0.msi',
+          'created'      => Time.parse('1995-04-11 11:05am'),
+          'createdBy'    => 'yzl',
+          'lastModified' => Time.parse('2013-11-10 10:10pm'),
+          'modifiedBy'   => 'schisamo',
+          'lastUpdated'  => Time.parse('2014-02-02 2:00pm'),
+          'size'         => '1024',
+          'mimeType'     => 'application/octet-stream',
+          'checksums'    => {
+            'md5' => 'MD5789',
+            'sha' => 'SHA101'
+          },
+          'originalChecksums' => {
+            'md5' => 'MD5789',
+            'sha' => 'SHA101'
+          }
+        )
+      end
+
       app.class_eval do
         def artifacts_for_conditions(&block)
           if block.call
@@ -125,6 +150,7 @@ module Artifactory
                 'results' => [
                   { 'uri' => server_url.join('/api/storage/libs-release-local/org/acme/artifact.deb') },
                   { 'uri' => server_url.join('/api/storage/ext-release-local/org/acme/artifact.deb') },
+                  { 'uri' => server_url.join('/api/storage/bin-release-local/org/acme/artifact 1.0.0.msi') },
                 ]
               )
             end


### PR DESCRIPTION
Artifactory does not escape artifact uri return from search, so if artifacts has been uploaded with space in name we must escape before calling client.get.
Also make sure we do not escape already escaped URIs

Signed-off-by: Rasmus Bergholdt <rasmus.bergholdt@gmail.com>
Issue #65