### PR TITLE
Allow downloading of large files

### DIFF
--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -502,7 +502,9 @@ module Artifactory
       destination = File.join(target, filename)
 
       File.open(destination, "wb") do |file|
-        file.write(client.get(download_uri))
+        client.get(download_uri) do |chunk|
+          file.write chunk
+        end
       end
 
       destination

--- a/spec/unit/resources/artifact_spec.rb
+++ b/spec/unit/resources/artifact_spec.rb
@@ -560,6 +560,20 @@ module Artifactory
           expect(Dir.entries(tmpdir)).to include("foobar.deb")
         end
       end
+
+      it "writes the file in chunks" do
+        Dir.mktmpdir("artifact_download") do |tmpdir|
+          subject.download_uri = "/artifact.deb"
+
+          expect(client).to receive(:get).and_yield("some content")
+
+          file = double("file")
+          expect(File).to receive(:open).with(File.join(tmpdir, "artifact.deb"), "wb").and_yield(file)
+          expect(file).to receive(:write).with("some content")
+
+          subject.download(tmpdir)
+        end
+      end
     end
 
     describe "#relative_path" do


### PR DESCRIPTION
This updates `Artifact#download` to write to disk in chunks as data is read from the underlying Socket. This ensures a large file download won't cause Ruby to throw a `NoMemoryError` error, especially on Windows.

Fixes #83

Signed-off-by: Seth Chisamore <schisamo@chef.io>

/cc @chef/engineering-services 