### PR TITLE
Use require_relative for link and remove appveyor links

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,0 @@
-daysUntilLock: 60

--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ client.all_plugins #=> [...]
 
 This pattern is slightly less eye-appealing, but it will ensure that your code is threadsafe.
 
-
 Development
 -----------
 1. Clone the project on GitHub
@@ -260,7 +259,6 @@ Important Notes:
 - **The tests must be be idempotent.** The HTTP calls made during a test should be able to be run over and over.
 - **Tests are order independent.** The default RSpec configuration randomizes the test order, so this should not be a problem.
 
-
 ## Maintainer
 
 This project is maintained by Chef's Release Engineering Team (releng@chef.io).
@@ -268,7 +266,7 @@ This project is maintained by Chef's Release Engineering Team (releng@chef.io).
 ## License
 
 ```text
-Copyright 2013-2018 Chef Software, Inc.
+Copyright 2013-2019 Chef Software, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -283,5 +281,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-[appveyor]: https://ci.appveyor.com/project/chef/artifactory-client
 [gem]: https://rubygems.org/gems/artifactory

--- a/lib/artifactory.rb
+++ b/lib/artifactory.rb
@@ -15,7 +15,7 @@
 #
 
 require "pathname"
-require "artifactory/version"
+require_relative "artifactory/version"
 
 module Artifactory
   autoload :Client,       "artifactory/client"

--- a/lib/artifactory/defaults.rb
+++ b/lib/artifactory/defaults.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "artifactory/version"
+require_relative "version"
 
 module Artifactory
   module Defaults


### PR DESCRIPTION
We don't test with appveyor anymore. Also use require_relative as it's faster.

Signed-off-by: Tim Smith <tsmith@chef.io>