### PR TITLE
Avoid deprecated URI methods

### DIFF
--- a/lib/artifactory/resources/base.rb
+++ b/lib/artifactory/resources/base.rb
@@ -243,7 +243,8 @@ module Artifactory
       #   the URL-safe version of the string
       #
       def url_safe(value)
-        URI.escape(URI.unescape(value.to_s))
+        p = URI::Parser.new
+        p.escape(p.unescape(value.to_s))
       end
     end
 


### PR DESCRIPTION
## Description

URI.escape and URI.unescape are deprecated; Using
URI::Parser methods avoids the warnings while yielding
the same net result.

## Related Issue
Fixes #128 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- **N/A** I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
