### PR TITLE
Follow redirects in client.get

### DIFF
--- a/lib/artifactory/client.rb
+++ b/lib/artifactory/client.rb
@@ -258,8 +258,16 @@ module Artifactory
 
         if block_given?
           http.request(request) do |response|
-            response.read_body do |chunk|
-              yield chunk
+            case response
+            when Net::HTTPRedirection
+              redirect = response["location"]
+              request(verb, redirect, data, headers, &block)
+            when Net::HTTPSuccess
+              response.read_body do |chunk|
+                yield chunk
+              end
+            else
+              error(response)
             end
           end
         else


### PR DESCRIPTION
## Description

When called with a block, `client.get` would not follow redirects and
would yield an empty string back to the block. `client.get` without a
block would properly follow redirects. The same redirection logic
should be used in both places.

Fixes 131

Signed-off-by: Josh Gitlin <jgitlin@pinnacle21.com>
## Related Issue
https://github.com/chef/artifactory-client/issues/131

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
