### PR TITLE
Add rexml as an explicit runtime dependency

### DIFF
--- a/artifactory.gemspec
+++ b/artifactory.gemspec
@@ -17,5 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency("rexml")
+
   spec.required_ruby_version = ">= 2.3"
 end


### PR DESCRIPTION
## Description
[rexml is a bundled gem since Ruby 3](https://bugs.ruby-lang.org/issues/16485), which means that it needs to be added to the gemspec/Gemfile in order to be `require`d.

The lack of the explicit dependency caused the error `LoadError: cannot load such file -- rexml/document` in our staging/prod environments, which has been tricky to debug because in dev environments we have test dependencies that depend on rexml and therefore mitigate its absence in the `artifactory` gemspec.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
