### PR TITLE
Retire <2.7 and add 3.0-3.3

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,5 +1,15 @@
 steps:
 
+- label: run-lint-and-specs-ruby-2.7
+  command:
+    - bundle config set --local without docs debug
+    - bundle install --jobs=7 --retry=3
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.7-buster
+
 - label: run-lint-and-specs-ruby-3.0
   command:
     - bundle config set --local without docs debug

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,15 +1,5 @@
 steps:
 
-- label: run-lint-and-specs-ruby-2.7
-  command:
-    - bundle config set --local without docs debug
-    - bundle install --jobs=7 --retry=3
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7-buster
-
 - label: run-lint-and-specs-ruby-3.0
   command:
     - bundle config set --local without docs debug

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,35 +1,5 @@
 steps:
 
-- label: run-lint-and-specs-ruby-2.4
-  command:
-    - bundle config set --local without docs debug
-    - bundle install --jobs=7 --retry=3
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-buster
-
-- label: run-lint-and-specs-ruby-2.5
-  command:
-    - bundle config set --local without docs debug
-    - bundle install --jobs=7 --retry=3
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-buster
-
-- label: run-lint-and-specs-ruby-2.6
-  command:
-    - bundle config set --local without docs debug
-    - bundle install --jobs=7 --retry=3
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-buster
-
 - label: run-lint-and-specs-ruby-2.7
   command:
     - bundle config set --local without docs debug
@@ -39,6 +9,48 @@ steps:
     executor:
       docker:
         image: ruby:2.7-buster
+
+- label: run-lint-and-specs-ruby-3.0
+  command:
+    - bundle config set --local without docs debug
+    - bundle install --jobs=7 --retry=3
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.0-buster
+
+- label: run-lint-and-specs-ruby-3.1
+  command:
+    - bundle config set --local without docs debug
+    - bundle install --jobs=7 --retry=3
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.1-bookworm
+
+- label: run-lint-and-specs-ruby-3.2
+  command:
+    - bundle config set --local without docs debug
+    - bundle install --jobs=7 --retry=3
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.2-bookworm
+
+- label: run-lint-and-specs-ruby-3.3
+  command:
+    - bundle config set --local without docs debug
+    - bundle install --jobs=7 --retry=3
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.3-bookworm
+
+
 
 - label: run-lint-and-specs-windows
   command:

--- a/artifactory.gemspec
+++ b/artifactory.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 2.7"
 end

--- a/artifactory.gemspec
+++ b/artifactory.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Ruby 2.4 and 2.5 are broken due to `public_suffix-5.0.4 requires ruby version >= 2.6`, but also need to retire builders EOLed rubies. Keeping 2.7 around for now until some pull requests can get caught up first.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
