### PR TITLE
Client::request did not load X509 cert correctly

### DIFF
--- a/lib/artifactory/client.rb
+++ b/lib/artifactory/client.rb
@@ -242,7 +242,7 @@ module Artifactory
         if ssl_pem_file
           pem = File.read(ssl_pem_file)
           connection.cert = OpenSSL::X509::Certificate.new(pem)
-          connection.key = OpenSSL::PKey::RSA.new(pem)
+          connection.key = connection.cert.public_key
           connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
         end
 


### PR DESCRIPTION
When loading a custom X509 cert in Client::request, the gem attempted to call OpenSSL::PKey::RSA.new with the raw content of the key file which either no longer works or never worked.

## Description
Simply assign the RSA key by using the OpenSSL gem's built in member OpenSSL::X509::Certificate::public_key instead of calling OpenSSL::PKey::RSA.new.

## Related Issue

#172 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
