### PR TITLE
CHEF-29603 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ This project is maintained by Chef's Release Engineering Team (releng@chef.io).
 ## License
 
 ```text
-Copyright 2013-2019 Chef Software, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -282,3 +281,6 @@ limitations under the License.
 ```
 
 [gem]: https://rubygems.org/gems/artifactory
+
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/lib/artifactory.rb
+++ b/lib/artifactory.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/client.rb
+++ b/lib/artifactory/client.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/collections/artifact.rb
+++ b/lib/artifactory/collections/artifact.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/collections/base.rb
+++ b/lib/artifactory/collections/base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/collections/build.rb
+++ b/lib/artifactory/collections/build.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/configurable.rb
+++ b/lib/artifactory/configurable.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/defaults.rb
+++ b/lib/artifactory/defaults.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/errors.rb
+++ b/lib/artifactory/errors.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/artifact.rb
+++ b/lib/artifactory/resources/artifact.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/backup.rb
+++ b/lib/artifactory/resources/backup.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/base.rb
+++ b/lib/artifactory/resources/base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/build.rb
+++ b/lib/artifactory/resources/build.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/build_component.rb
+++ b/lib/artifactory/resources/build_component.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/group.rb
+++ b/lib/artifactory/resources/group.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/layout.rb
+++ b/lib/artifactory/resources/layout.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/ldap_setting.rb
+++ b/lib/artifactory/resources/ldap_setting.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/mail_server.rb
+++ b/lib/artifactory/resources/mail_server.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/plugin.rb
+++ b/lib/artifactory/resources/plugin.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/repository.rb
+++ b/lib/artifactory/resources/repository.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/system.rb
+++ b/lib/artifactory/resources/system.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/url_base.rb
+++ b/lib/artifactory/resources/url_base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/resources/user.rb
+++ b/lib/artifactory/resources/user.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/util.rb
+++ b/lib/artifactory/util.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/artifactory/version.rb
+++ b/lib/artifactory/version.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Chef Software, Inc.
+# Copyright (c) 2014-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2014-2024 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme
- `README.md:269` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
